### PR TITLE
Fix stone texture

### DIFF
--- a/data.py
+++ b/data.py
@@ -64,12 +64,12 @@ blocks = {
         'hierarchy': 5
     },
     '#': {
-        'char': '~',
+        'char': ' ',
         'name': 'Stone',
         'colours': {
             'fg': None,
             'bg': grey(.15),
-            'style': CLEAR
+            'style': None
         },
         'solid': True,
         'breakable': True,


### PR DESCRIPTION
The CLEAR style doesn't work on some terminals, such as screen, which just makes the character show up white. This fix makes it a space, which should make it work on all terminals.