### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python3 main.py"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Run on Repl.it](https://repl.it/badge/github/itsapi/pycraft)](https://repl.it/github/itsapi/pycraft)
+
 # Pycraft
 
 A command line based 2D Minecraft, runs best on *nix with Python 3.3+. Built by [grit96](https://github.com/grit96) and [olls](https://github.com/olls).


### PR DESCRIPTION
You can run this in browser through repl.it! This pull configures it.

![Capture](https://user-images.githubusercontent.com/39810066/70537812-12bcd700-1b2f-11ea-9226-108557fbb6a3.PNG)

_"This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@dialogarithm/pycraft)."_