### PR TITLE
fix int to size_t comparison by casting int to size_t

### DIFF
--- a/render_c_module.c
+++ b/render_c_module.c
@@ -1023,7 +1023,7 @@ render_map(PyObject *self, PyObject *args)
         frame.buffer[frame.cur_pos] = L'\0';
         int n_wprintf_written = wprintf(frame.buffer);
 
-        if (n_wprintf_written != frame.cur_pos)
+        if (n_wprintf_written >= 0 && (size_t)n_wprintf_written != frame.cur_pos)
         {
             PyErr_SetString(C_RENDERER_EXCEPTION, "wfprint messed up!");
             return NULL;


### PR DESCRIPTION
```
(.venv) [ 10:00ÖÖ ]  [ isidentical@x200:~/pycraft(master✔) ]
 $ python setup.py build
running build
running build_ext
building 'render_c' extension
creating build
creating build/temp.linux-x86_64-3.9-pydebug
gcc -pthread -Wno-unused-result -Wsign-compare -g -Og -Wall -fPIC -I/home/isidentical/.venv/include -I/usr/local/include/python3.9d -c render_c_module.c -o build/temp.linux-x86_64-3.9-pydebug/render_c_module.o
render_c_module.c: In function ‘render_map’:
render_c_module.c:1026:31: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
 1026 |         if (n_wprintf_written != frame.cur_pos)
      |                               ^~
```