### PR TITLE
resolve deprecation warnings about implicit int conversion

### DIFF
--- a/render_c_module.c
+++ b/render_c_module.c
@@ -713,7 +713,7 @@ fill_lighting_buffer(PyObject *lights, PyObject *bk_objects, PyObject *map, Sett
             .world_x = PyLong_AsLong(PyDict_GetItemString(py_light, "x")),
             .world_y = PyLong_AsLong(PyDict_GetItemString(py_light, "y")),
             .z = PyLong_AsLong(PyDict_GetItemString(py_light, "z")),
-            .radius = PyLong_AsLong(PyDict_GetItemString(py_light, "radius")),
+            .radius = PyLong_AsLong(PyNumber_Long(PyDict_GetItemString(py_light, "radius"))),
             .width = get_long_from_PyDict_or(py_light, "source_width", 1),
             .height = get_long_from_PyDict_or(py_light, "source_height", 1),
             .rgb = PyColour_AsColour(PyDict_GetItemString(py_light, "colour"))


### PR DESCRIPTION
```
/home/isidentical/pycraft/render_interface.py:35: DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
  return render_c.create_lighting_buffer(width, height, x, y, map_, slice_heights, bk_objects, sky_colour, day, lights, settings_ref)
```

With [bpo-36048](https://bugs.python.org/issue36048), implicit integer conversion removed from `PyLong_` family so we need to convert it explicitly. 